### PR TITLE
CMakeLists.txt: fix hang when >1 Camomile LV2 plugin is loaded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,11 @@ target_sources(CamomileFx PRIVATE ${CamomileSources} ${CamomilePdSources})
 
 add_library(Camomile_LV2 SHARED ${CamomileLV2Sources})
 target_link_libraries(Camomile_LV2 PRIVATE CamomileFx)
-set_target_properties(Camomile_LV2 PROPERTIES PREFIX "")
+set_target_properties(Camomile_LV2 PROPERTIES PREFIX "" CXX_STANDARD 20)
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    target_compile_options(Camomile_LV2 PRIVATE "-fno-gnu-unique")
+endif()
 
 set(CAMOMILE_COMPILE_DEFINITIONS
     JUCE_APP_CONFIG_HEADER="${SOURCES_DIRECTORY}/PluginConfig.h"


### PR DESCRIPTION
This fixes issue #286 on the mothership repository.

This issue was ultimately caused by an object buried in the JUCE code having an inappropriate scope - GCC made the object a "unique global symbol", which means there is only one instance across the current process. When multiple plugins were loaded, they all shared this instance, but did not share other relevant objects (from the JUCE code), causing havoc. The fix is to ban GCC from marking symbols as "unique global".

Also set the C++ standard to be C++20 for the Camomile_LV2 meta-plugin, in line with the other meta-plugins.