### PR TITLE
#300: openpanel/savepanel: ensure files can be selected in file chooser

### DIFF
--- a/Source/PluginEditorInteraction.cpp
+++ b/Source/PluginEditorInteraction.cpp
@@ -259,7 +259,10 @@ bool CamomileEditorMessageManager::processMessages()
             m_file_chooser = std::make_unique<FileChooser>("Open...", File(message[1]), "", useNative);
             if(m_file_chooser != nullptr)
             {
-                auto constexpr folderChooserFlags = FileChooserFlags::openMode | FileChooserFlags::canSelectDirectories;
+                auto constexpr folderChooserFlags = \
+                    FileChooserFlags::openMode \
+                    | FileChooserFlags::canSelectFiles \
+                    | FileChooserFlags::canSelectDirectories;
                 auto const suspend = !message[2].empty();
                 WeakReference<CamomileEditorMessageManager> weakReference(this);
                 m_file_chooser->launchAsync(folderChooserFlags, [=, this](FileChooser const& fileChooser)
@@ -292,7 +295,11 @@ bool CamomileEditorMessageManager::processMessages()
             m_file_chooser = std::make_unique<FileChooser>("Save...", File(message[1]), "", useNative);
             if(m_file_chooser != nullptr)
             {
-                auto constexpr folderChooserFlags = FileChooserFlags::saveMode | FileChooserFlags::canSelectDirectories | FileChooserFlags::warnAboutOverwriting;
+                auto constexpr folderChooserFlags = \
+                    FileChooserFlags::saveMode \
+                    | FileChooserFlags::canSelectFiles \
+                    | FileChooserFlags::canSelectDirectories \
+                    | FileChooserFlags::warnAboutOverwriting;
                 auto const suspend = !message[2].empty();
                 WeakReference<CamomileEditorMessageManager> weakReference(this);
                 m_file_chooser->launchAsync(folderChooserFlags, [=, this](FileChooser const& fileChooser)

--- a/Source/PluginEditorInteraction.cpp
+++ b/Source/PluginEditorInteraction.cpp
@@ -308,15 +308,11 @@ bool CamomileEditorMessageManager::processMessages()
                     {
                         return;
                     }
-                    auto const file = fileChooser.getResult();
-                    if(!file.existsAsFile())
-                    {
-                        return;
-                    }
                     if(suspend)
                     {
                         m_processor.suspendProcessing(true);
                     }
+                    auto const file = fileChooser.getResult();
                     auto const path = file.getFullPathName().replaceCharacter('\\', '/').toStdString();
                     m_processor.enqueueMessages(string_savepanel, string_symbol, {path});
                     if(suspend)


### PR DESCRIPTION
Fixes [#300](https://github.com/pierreguillot/Camomile/issues/300) on the mothership repository.

Also changes the behaviour when savepanel is triggered and the file chooser returns a path where no file exists. Currently, a non-existent path is treated as an error, and the path is *not* passed to the `savepanel` symbol in the patch. However, this prevents a user from saving audio to a new file. This PR removes the check for the existence of a file at the path returned by the file chooser (when this was triggered by savepanel).